### PR TITLE
Remove dependency on packageBin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install this plugin in a project, simply add the following line to
 
 `addSbtPlugin("me.amanj" %% "sbt-deploy" % "${VERSION_OF_THE_PLUGIN_HERE}")`
 
-Please not that this plugin works with both sbt `0.13.x` and `1.0.x`.
+Please note that this plugin works with both sbt `0.13.x` and `1.0.x`.
 
 
 This Plugin is composed of the following subplugins:
@@ -45,7 +45,7 @@ This Plugin is composed of the following subplugins:
 - `distributedProjectName` expects a `java.lang.String`, and defaults to
   the name of the project that enables this plugin. This is used to customize
   the name of directory that the project tarball extracts to.
-- `assemblyClassifier` extects a `java.lang.String`, and defaults to
+- `assemblyClassifier` expects a `java.lang.String`, and defaults to
   `jar-with-dependencies`. This is used to customize the name of the fat jars.
 
 ### DistributionPlugin introduces the following settings:

--- a/src/main/scala/DistributionPlugin.scala
+++ b/src/main/scala/DistributionPlugin.scala
@@ -31,7 +31,6 @@ object DistributionPlugin extends AutoPlugin {
     confSrcDir := (resourceDirectory in Compile).value / "conf",
     targetDir := (target in Compile).value,
     enableShellCheck := true,
-    exportJars := true,
     // When publishing (either to local repo, or public), make sure to publish the
     // tarball is published too
     packagedArtifacts in publish := {


### PR DESCRIPTION
Removed `exportJars` setting.
Please refer to https://www.scala-sbt.org/1.0/docs/Howto-Classpaths.html for detailed description.

When `exportJars` is set, the expected output is the output of `packageBin` instead of `compile`. Thus to run tests via `test:test` or to just compile via `test:compile` a full packaging is performed. 